### PR TITLE
Fix Archive.org importer date update

### DIFF
--- a/RelistenApi/Services/Importers/ArchiveOrgImporterUtils.cs
+++ b/RelistenApi/Services/Importers/ArchiveOrgImporterUtils.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Relisten.Vendor.ArchiveOrg.Metadata;
+
+namespace Relisten.Import;
+
+public static class ArchiveOrgImporterUtils
+{
+    private static readonly Regex ExtractDateFromIdentifier = new(@"(\d{4}-\d{2}-\d{2})");
+
+    // thanks to this trouble child: https://archive.org/metadata/lotus2011-16-07.lotus2011-16-07_Neumann
+    public static string FixDisplayDate(Metadata meta)
+    {
+        if (meta == null || string.IsNullOrEmpty(meta.date))
+        {
+            return null;
+        }
+
+        var parts = meta.date.Split('-');
+
+        if (parts.Length == 3)
+        {
+            var year = parts[0];
+            var month = parts[1];
+            var day = parts[2];
+
+            var changed = false;
+
+            if (month == "00")
+            {
+                month = "XX";
+                changed = true;
+            }
+
+            if (day == "00")
+            {
+                day = "XX";
+                changed = true;
+            }
+
+            if (changed)
+            {
+                return string.Join('-', year, month, day);
+            }
+        }
+
+        // 1970-03-XX or 1970-XX-XX which is okay because it is handled by the rebuild
+        if (meta.date.Contains('X'))
+        {
+            return meta.date;
+        }
+
+        if (meta.date == "2013-14-02")
+        {
+            // this date from The Werks always gives us issues and TryFlippingMonthAndDate doesn't work...I suspect
+            // some sort cultural issue because I cannot reproduce this locally
+            return "2013-02-14";
+        }
+
+        // happy case
+        if (TestDate(meta.date))
+        {
+            return meta.date;
+        }
+
+        var d = TryFlippingMonthAndDate(meta.date);
+
+        if (d != null)
+        {
+            return d;
+        }
+
+        // try to parse it out of the identifier
+        var matches = ExtractDateFromIdentifier.Match(meta.identifier);
+
+        if (matches.Success)
+        {
+            var tdate = matches.Groups[1].Value;
+
+            if (TestDate(tdate))
+            {
+                return tdate;
+            }
+
+            var flipped = TryFlippingMonthAndDate(tdate);
+
+            if (flipped != null)
+            {
+                return flipped;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TestDate(string date)
+    {
+        return DateTime.TryParseExact(date, "yyyy-MM-dd",
+            DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out _);
+    }
+
+    private static string TryFlippingMonthAndDate(string date)
+    {
+        // not a valid date
+        var parts = date.Split('-');
+
+        // try to see if it is YYYY-DD-MM instead
+        if (parts.Length > 2 && int.TryParse(parts[1], out var month))
+        {
+            if (month > 12)
+            {
+                // rearrange to YYYY-MM-DD
+                var dateStr = parts[0] + "-" + parts[2] + "-" + parts[1];
+
+                if (TestDate(dateStr))
+                {
+                    return dateStr;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/RelistenApiTests/Importers/ArchiveOrg/TestArchiveOrgFixDisplayDate.cs
+++ b/RelistenApiTests/Importers/ArchiveOrg/TestArchiveOrgFixDisplayDate.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Relisten.Import;
+using Relisten.Vendor.ArchiveOrg.Metadata;
+
+namespace RelistenApiTests.Importers.ArchiveOrg;
+
+[TestFixture]
+public class TestArchiveOrgFixDisplayDate
+{
+    private static string InvokeFixDisplayDate(string date)
+    {
+        var meta = new Metadata { date = date, identifier = "id" };
+        return ArchiveOrgImporterUtils.FixDisplayDate(meta);
+    }
+
+    [Test]
+    public void FixDisplayDate_ShouldHandleZeroMonthOrDayAcrossYears()
+    {
+        for (var year = 1950; year <= 2050; year++)
+        {
+            InvokeFixDisplayDate($"{year}-05-05").Should().Be($"{year}-05-05");
+            InvokeFixDisplayDate($"{year}-00-05").Should().Be($"{year}-XX-05");
+            InvokeFixDisplayDate($"{year}-05-00").Should().Be($"{year}-05-XX");
+            InvokeFixDisplayDate($"{year}-00-00").Should().Be($"{year}-XX-XX");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- simplify FixDisplayDate with early return
- update ArchiveOrgImporter to re-import shows when display_date changes
- adjust unit test harness for new util class

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684b26cf088883328b09d276650fd3ea