### PR TITLE
[codex] Update v2 search response contract

### DIFF
--- a/RelistenApi/Controllers/SearchController.cs
+++ b/RelistenApi/Controllers/SearchController.cs
@@ -25,21 +25,33 @@ namespace Relisten.Controllers
 
         [HttpGet("search")]
         [ProducesResponseType(typeof(SearchResults), 200)]
-        public async Task<IActionResult> Search([FromQuery] string q, [FromQuery] int? artist_id = null)
+        public async Task<IActionResult> Search(
+            [FromQuery] string? q,
+            [FromQuery] int? artist_id = null,
+            [FromQuery] bool artists = true,
+            [FromQuery] bool shows = true,
+            [FromQuery] bool songs = true,
+            [FromQuery] bool sources = true,
+            [FromQuery] bool tours = true,
+            [FromQuery] bool venues = true)
         {
-            if (q.Length < 3)
+            var searchTerm = q?.Trim();
+            var options = new SearchOptions
             {
-                return JsonSuccess(new SearchResults
-                {
-                    Artists = new List<SlimArtist>(),
-                    Shows = new List<ShowWithSlimArtist>(),
-                    Source = new List<SourceWithSlimArtist>(),
-                    Tours = new List<TourWithSlimArtist>(),
-                    Venues = new List<VenueWithSlimArtist>()
-                });
+                Artists = artists,
+                Shows = shows,
+                Songs = songs,
+                Sources = sources,
+                Tours = tours,
+                Venues = venues
+            };
+
+            if (string.IsNullOrWhiteSpace(searchTerm) || searchTerm.Length < 3 || !options.AnyEnabled)
+            {
+                return JsonSuccess(SearchResults.Empty());
             }
 
-            return JsonSuccess(await _searchService.Search(q, artist_id));
+            return JsonSuccess(await _searchService.Search(searchTerm, artist_id, options));
         }
     }
 }

--- a/RelistenApi/Controllers/SearchController.cs
+++ b/RelistenApi/Controllers/SearchController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Relisten.Api;
@@ -27,7 +28,7 @@ namespace Relisten.Controllers
         [ProducesResponseType(typeof(SearchResults), 200)]
         public async Task<IActionResult> Search(
             [FromQuery] string? q,
-            [FromQuery] int? artist_id = null,
+            [FromQuery] Guid? artist_uuid = null,
             [FromQuery] bool artists = true,
             [FromQuery] bool shows = true,
             [FromQuery] bool songs = true,
@@ -51,7 +52,7 @@ namespace Relisten.Controllers
                 return JsonSuccess(SearchResults.Empty());
             }
 
-            return JsonSuccess(await _searchService.Search(searchTerm, artist_id, options));
+            return JsonSuccess(await _searchService.Search(searchTerm, artist_uuid, options));
         }
     }
 }

--- a/RelistenApi/Controllers/SearchController.cs
+++ b/RelistenApi/Controllers/SearchController.cs
@@ -8,7 +8,7 @@ using Relisten.Data;
 
 namespace Relisten.Controllers
 {
-    [Route("api/v2")]
+    [Route("api")]
     [Produces("application/json")]
     public class SearchController : RelistenBaseController
     {
@@ -24,7 +24,8 @@ namespace Relisten.Controllers
             _searchService = searchService;
         }
 
-        [HttpGet("search")]
+        [HttpGet("v2/search")]
+        [HttpGet("v3/search")]
         [ProducesResponseType(typeof(SearchResults), 200)]
         public async Task<IActionResult> Search(
             [FromQuery] string? q,

--- a/RelistenApi/Models/SearchResults.cs
+++ b/RelistenApi/Models/SearchResults.cs
@@ -11,11 +11,36 @@ namespace Relisten.Api.Models
 
         [Required] public IEnumerable<SetlistSongWithSlimArtist> Songs { get; set; } = null!;
 
-        [Required] public IEnumerable<SourceWithSlimArtist> Source { get; set; } = null!;
+        [Required] public IEnumerable<SourceWithSlimArtist> Sources { get; set; } = null!;
 
         [Required] public IEnumerable<TourWithSlimArtist> Tours { get; set; } = null!;
 
         [Required] public IEnumerable<VenueWithSlimArtist> Venues { get; set; } = null!;
+
+        public static SearchResults Empty()
+        {
+            return new SearchResults
+            {
+                Artists = new List<SlimArtist>(),
+                Shows = new List<ShowWithSlimArtist>(),
+                Songs = new List<SetlistSongWithSlimArtist>(),
+                Sources = new List<SourceWithSlimArtist>(),
+                Tours = new List<TourWithSlimArtist>(),
+                Venues = new List<VenueWithSlimArtist>()
+            };
+        }
+    }
+
+    public class SearchOptions
+    {
+        public bool Artists { get; set; } = true;
+        public bool Shows { get; set; } = true;
+        public bool Songs { get; set; } = true;
+        public bool Sources { get; set; } = true;
+        public bool Tours { get; set; } = true;
+        public bool Venues { get; set; } = true;
+
+        public bool AnyEnabled => Artists || Shows || Songs || Sources || Tours || Venues;
     }
 
     public class ShowWithSlimArtist : Show

--- a/RelistenApi/Services/Data/SearchService.cs
+++ b/RelistenApi/Services/Data/SearchService.cs
@@ -11,13 +11,13 @@ namespace Relisten.Data
         {
         }
 
-        public async Task<SearchResults> Search(string searchTerm, int? artistId = null, SearchOptions? options = null)
+        public async Task<SearchResults> Search(string searchTerm, Guid? artistUuid = null, SearchOptions? options = null)
         {
             options ??= new SearchOptions();
 
             return await db.WithConnection(async con =>
             {
-                var parms = new {searchTerm, artistId};
+                var parms = new {searchTerm, artistUuid};
 
                 return new SearchResults
                 {
@@ -29,9 +29,9 @@ namespace Relisten.Data
 							LEFT JOIN (
 								SELECT artist_id, COUNT(*) as show_count FROM shows GROUP BY artist_id
 							) show_counts ON show_counts.artist_id = artists.id
-						WHERE
-							name ILIKE '%' || @searchTerm || '%'
-							{(artistId.HasValue ? "AND id = @artistId" : "")}
+							WHERE
+								name ILIKE '%' || @searchTerm || '%'
+								{(artistUuid.HasValue ? "AND artists.uuid = @artistUuid" : "")}
 						ORDER BY
 							COALESCE(show_counts.show_count, 0) DESC, name
 						LIMIT 20;
@@ -57,7 +57,7 @@ namespace Relisten.Data
 								LEFT JOIN years y ON s.year_id = y.id
 						WHERE
 							s.display_date ILIKE '%' || @searchTerm || '%'
-							{(artistId.HasValue ? "AND s.artist_id = @artistId" : "")}
+							{(artistUuid.HasValue ? "AND a.uuid = @artistUuid" : "")}
 						ORDER BY
 							COALESCE(cnt.source_count, 0) DESC, s.display_date DESC
 						LIMIT 20;
@@ -80,7 +80,7 @@ namespace Relisten.Data
 							JOIN artists a ON s.artist_id = a.id
 							WHERE
 								s.name ILIKE '%' || @searchTerm || '%'
-								{(artistId.HasValue ? "AND s.artist_id = @artistId" : "")}
+								{(artistUuid.HasValue ? "AND a.uuid = @artistUuid" : "")}
 		                GROUP BY
 		                    a.id, s.id
 		                ORDER BY shows_played_at DESC, s.name
@@ -110,7 +110,7 @@ namespace Relisten.Data
 							OR s.taper ILIKE '%' || @searchTerm || '%'
 							OR s.transferrer ILIKE '%' || @searchTerm || '%'
 							OR s.lineage ILIKE '%' || @searchTerm || '%')
-							{(artistId.HasValue ? "AND s.artist_id = @artistId" : "")}
+							{(artistUuid.HasValue ? "AND a.uuid = @artistUuid" : "")}
 						ORDER BY
 							s.avg_rating_weighted DESC, s.duration DESC, s.display_date DESC
 						LIMIT 20;
@@ -130,7 +130,7 @@ namespace Relisten.Data
 							LEFT JOIN shows sh ON sh.tour_id = t.id
 						WHERE
 							t.name ILIKE '%' || @searchTerm || '%'
-							{(artistId.HasValue ? "AND t.artist_id = @artistId" : "")}
+							{(artistUuid.HasValue ? "AND a.uuid = @artistUuid" : "")}
 						GROUP BY
 							t.id, a.id
 						ORDER BY
@@ -154,7 +154,7 @@ namespace Relisten.Data
 							(v.name ILIKE '%' || @searchTerm || '%'
 							OR v.location ILIKE '%' || @searchTerm || '%'
 					        OR v.past_names ILIKE '%' || @searchTerm || '%')
-							{(artistId.HasValue ? "AND v.artist_id = @artistId" : "")}
+							{(artistUuid.HasValue ? "AND a.uuid = @artistUuid" : "")}
 						GROUP BY
 							v.id, a.id
 						ORDER BY

--- a/RelistenApi/Services/Data/SearchService.cs
+++ b/RelistenApi/Services/Data/SearchService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Dapper;
 using Relisten.Api.Models;
 
@@ -10,66 +11,97 @@ namespace Relisten.Data
         {
         }
 
-        public async Task<SearchResults> Search(string searchTerm, int? artistId = null)
+        public async Task<SearchResults> Search(string searchTerm, int? artistId = null, SearchOptions? options = null)
         {
+            options ??= new SearchOptions();
+
             return await db.WithConnection(async con =>
             {
                 var parms = new {searchTerm, artistId};
 
                 return new SearchResults
                 {
-                    Artists = await con.QueryAsync<SlimArtist>($@"
+                    Artists = options.Artists ? await con.QueryAsync<SlimArtist>($@"
 						SELECT
-							*
+							artists.*
 						FROM
 							artists
+							LEFT JOIN (
+								SELECT artist_id, COUNT(*) as show_count FROM shows GROUP BY artist_id
+							) show_counts ON show_counts.artist_id = artists.id
 						WHERE
 							name ILIKE '%' || @searchTerm || '%'
 							{(artistId.HasValue ? "AND id = @artistId" : "")}
+						ORDER BY
+							COALESCE(show_counts.show_count, 0) DESC, name
 						LIMIT 20;
-					", parms),
-                    Shows = await con.QueryAsync<ShowWithSlimArtist, SlimArtist, ShowWithSlimArtist>($@"
+					", parms) : Array.Empty<SlimArtist>(),
+                    Shows = options.Shows ? await con.QueryAsync<ShowWithSlimArtist, SlimArtist, ShowWithSlimArtist>($@"
 						SELECT
-							s.*, a.*
-						FROM
-							shows s
-							JOIN artists a ON s.artist_id = a.id
+								s.*,
+								a.uuid as artist_uuid,
+								cnt.max_updated_at as most_recent_source_updated_at,
+								COALESCE(cnt.source_count, 0) as source_count,
+								COALESCE(cnt.has_soundboard_source, false) as has_soundboard_source,
+								COALESCE(cnt.has_flac, false) as has_streamable_flac_source,
+								v.uuid as venue_uuid,
+								t.uuid as tour_uuid,
+								y.uuid as year_uuid,
+								a.*
+							FROM
+								shows s
+								JOIN artists a ON s.artist_id = a.id
+								LEFT JOIN show_source_information cnt ON cnt.show_id = s.id
+								LEFT JOIN venues v ON s.venue_id = v.id
+								LEFT JOIN tours t ON s.tour_id = t.id
+								LEFT JOIN years y ON s.year_id = y.id
 						WHERE
 							s.display_date ILIKE '%' || @searchTerm || '%'
 							{(artistId.HasValue ? "AND s.artist_id = @artistId" : "")}
+						ORDER BY
+							COALESCE(cnt.source_count, 0) DESC, s.display_date DESC
 						LIMIT 20;
 					", (s, a) =>
                     {
                         s.slim_artist = a;
                         return s;
-                    }, parms),
-                    Songs = await con.QueryAsync<SetlistSongWithSlimArtist, SlimArtist, SetlistSongWithSlimArtist>($@"
+                    }, parms) : Array.Empty<ShowWithSlimArtist>(),
+                    Songs = options.Songs ? await con.QueryAsync<SetlistSongWithSlimArtist, SlimArtist, SetlistSongWithSlimArtist>($@"
 		                SELECT
-		                    s.*, COUNT(shows.id) as shows_played_at, a.*
+			                    s.*,
+			                    a.uuid as artist_uuid,
+			                    COUNT(shows.id) as shows_played_at,
+			                    a.*
 		                FROM
 		                    setlist_songs s
 		                    LEFT JOIN setlist_songs_plays p ON p.played_setlist_song_id = s.id
 		                    LEFT JOIN setlist_shows set_shows ON set_shows.id = p.played_setlist_show_id
-		                    JOIN shows shows ON shows.date = set_shows.date
+		                    JOIN shows shows ON shows.date = set_shows.date AND shows.artist_id = s.artist_id
 							JOIN artists a ON s.artist_id = a.id
 							WHERE
 								s.name ILIKE '%' || @searchTerm || '%'
 								{(artistId.HasValue ? "AND s.artist_id = @artistId" : "")}
 		                GROUP BY
 		                    a.id, s.id
-		                ORDER BY s.name
+		                ORDER BY shows_played_at DESC, s.name
 						LIMIT 20;
 					", (s, a) =>
                     {
                         s.slim_artist = a;
                         return s;
-                    }, parms),
-                    Source = await con.QueryAsync<SourceWithSlimArtist, SlimArtist, SourceWithSlimArtist>($@"
+                    }, parms) : Array.Empty<SetlistSongWithSlimArtist>(),
+                    Sources = options.Sources ? await con.QueryAsync<SourceWithSlimArtist, SlimArtist, SourceWithSlimArtist>($@"
 						SELECT
-							s.*, a.*
-						FROM
-							sources s
-							JOIN artists a ON s.artist_id = a.id
+								s.*,
+								a.uuid as artist_uuid,
+								sh.uuid as show_uuid,
+								v.uuid as venue_uuid,
+								a.*
+							FROM
+								sources s
+								JOIN artists a ON s.artist_id = a.id
+								LEFT JOIN shows sh ON sh.id = s.show_id
+								LEFT JOIN venues v ON v.id = s.venue_id
 						WHERE
 							(s.upstream_identifier ILIKE '%' || @searchTerm || '%'
 							OR s.description ILIKE '%' || @searchTerm || '%'
@@ -79,44 +111,60 @@ namespace Relisten.Data
 							OR s.transferrer ILIKE '%' || @searchTerm || '%'
 							OR s.lineage ILIKE '%' || @searchTerm || '%')
 							{(artistId.HasValue ? "AND s.artist_id = @artistId" : "")}
+						ORDER BY
+							s.avg_rating_weighted DESC, s.duration DESC, s.display_date DESC
 						LIMIT 20;
 					", (s, a) =>
                     {
                         s.slim_artist = a;
                         return s;
-                    }, parms),
-                    Tours = await con.QueryAsync<TourWithSlimArtist, SlimArtist, TourWithSlimArtist>($@"
+                    }, parms) : Array.Empty<SourceWithSlimArtist>(),
+                    Tours = options.Tours ? await con.QueryAsync<TourWithSlimArtist, SlimArtist, TourWithSlimArtist>($@"
 						SELECT
-							t.*, a.*
+								t.*,
+								a.uuid as artist_uuid,
+								a.*
 						FROM
 							tours t
 							JOIN artists a ON t.artist_id = a.id
+							LEFT JOIN shows sh ON sh.tour_id = t.id
 						WHERE
 							t.name ILIKE '%' || @searchTerm || '%'
 							{(artistId.HasValue ? "AND t.artist_id = @artistId" : "")}
+						GROUP BY
+							t.id, a.id
+						ORDER BY
+							COUNT(sh.id) DESC, t.start_date DESC, t.name
 					    LIMIT 20;
 					", (t, a) =>
                     {
                         t.slim_artist = a;
                         return t;
-                    }, parms),
-                    Venues = await con.QueryAsync<VenueWithSlimArtist, SlimArtist, VenueWithSlimArtist>($@"
+                    }, parms) : Array.Empty<TourWithSlimArtist>(),
+                    Venues = options.Venues ? await con.QueryAsync<VenueWithSlimArtist, SlimArtist, VenueWithSlimArtist>($@"
 						SELECT
-							v.*, a.*
+								v.*,
+								a.uuid as artist_uuid,
+								a.*
 						FROM
 							venues v
 							JOIN artists a ON v.artist_id = a.id
+							LEFT JOIN shows sh ON sh.venue_id = v.id
 						WHERE
 							(v.name ILIKE '%' || @searchTerm || '%'
 							OR v.location ILIKE '%' || @searchTerm || '%'
 					        OR v.past_names ILIKE '%' || @searchTerm || '%')
 							{(artistId.HasValue ? "AND v.artist_id = @artistId" : "")}
+						GROUP BY
+							v.id, a.id
+						ORDER BY
+							COUNT(sh.id) DESC, v.name
 						LIMIT 20;
 					", (v, a) =>
                     {
                         v.slim_artist = a;
                         return v;
-                    }, parms)
+                    }, parms) : Array.Empty<VenueWithSlimArtist>()
                 };
             });
         }

--- a/RelistenApi/Startup.cs
+++ b/RelistenApi/Startup.cs
@@ -175,7 +175,16 @@ namespace Relisten
                     var migrationsAssembly = typeof(Startup).Assembly;
                     var databaseProvider = new PostgresqlDatabaseProvider(pg);
                     var migrator = new SimpleMigrator(migrationsAssembly, databaseProvider);
-                    migrator.Load();
+                    try
+                    {
+                        migrator.Load();
+                    }
+                    catch (MissingMigrationException ex) when (HostEnvironment.IsDevelopment())
+                    {
+                        Log.Warning(ex,
+                            "Skipping migration validation because the local development database is ahead of this checkout.");
+                        return db;
+                    }
 
                     if (migrator.CurrentMigration == null || migrator.CurrentMigration.Version == 0)
                     {

--- a/RelistenApiTests/Controllers/TestSearchController.cs
+++ b/RelistenApiTests/Controllers/TestSearchController.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Relisten.Api.Models;
+using Relisten.Controllers;
+
+namespace RelistenApiTests.Controllers;
+
+[TestFixture]
+public class TestSearchController
+{
+    [Test]
+    public async Task Search_WhenQueryIsMissing_ReturnsCompleteEmptyResults()
+    {
+        var result = await new SearchController(null!, null!, null!, null!).Search(null);
+
+        var results = ExtractResults(result);
+        AssertEmptyResultsAreComplete(results);
+    }
+
+    [Test]
+    public async Task Search_WhenQueryIsTooShort_ReturnsCompleteEmptyResults()
+    {
+        var result = await new SearchController(null!, null!, null!, null!).Search("tw");
+
+        var results = ExtractResults(result);
+        AssertEmptyResultsAreComplete(results);
+    }
+
+    [Test]
+    public async Task Search_WhenAllBucketsAreDisabled_ReturnsCompleteEmptyResults()
+    {
+        var result = await new SearchController(null!, null!, null!, null!).Search(
+            "tweezer",
+            artists: false,
+            shows: false,
+            songs: false,
+            sources: false,
+            tours: false,
+            venues: false);
+
+        var results = ExtractResults(result);
+        AssertEmptyResultsAreComplete(results);
+    }
+
+    private static SearchResults ExtractResults(IActionResult result)
+    {
+        result.Should().BeOfType<JsonResult>();
+        return ((JsonResult) result).Value.Should().BeOfType<SearchResults>().Subject;
+    }
+
+    private static void AssertEmptyResultsAreComplete(SearchResults results)
+    {
+        results.Artists.Should().BeEmpty();
+        results.Shows.Should().BeEmpty();
+        results.Songs.Should().BeEmpty();
+        results.Sources.Should().BeEmpty();
+        results.Tours.Should().BeEmpty();
+        results.Venues.Should().BeEmpty();
+    }
+}

--- a/RelistenApiTests/Controllers/TestSearchController.cs
+++ b/RelistenApiTests/Controllers/TestSearchController.cs
@@ -31,6 +31,7 @@ public class TestSearchController
     {
         var result = await new SearchController(null!, null!, null!, null!).Search(
             "tweezer",
+            artist_uuid: null,
             artists: false,
             shows: false,
             songs: false,
@@ -40,6 +41,16 @@ public class TestSearchController
 
         var results = ExtractResults(result);
         AssertEmptyResultsAreComplete(results);
+    }
+
+    [Test]
+    public void Search_UsesArtistUuidQueryParameter()
+    {
+        var parameters = typeof(SearchController).GetMethod(nameof(SearchController.Search))!.GetParameters();
+
+        parameters.Select(parameter => parameter.Name).Should().Contain("artist_uuid");
+        parameters.Select(parameter => parameter.Name).Should().NotContain("artist_id");
+        parameters.Single(parameter => parameter.Name == "artist_uuid").ParameterType.Should().Be(typeof(Guid?));
     }
 
     private static SearchResults ExtractResults(IActionResult result)


### PR DESCRIPTION
## Summary

This updates `/api/v2/search` and adds `/api/v3/search` to return a cleaner, more useful response for frontend search experiences.

- BREAKING: rename top-level `Source` bucket to `Sources`
- add per-bucket query toggles so clients can skip expensive or irrelevant buckets
- return complete empty result objects for missing, blank, or too-short queries
- populate UUID fields that were previously defaulting to zero UUIDs in search results
- order result buckets by usefulness instead of arbitrary database order
- fix inflated song play counts by scoping date joins to the matching artist
- allow local development startup when a dev DB is ahead of checked-out migrations

## Frontend Handoff for Switz

### Endpoint

```text
GET /api/{v2|v3}/search?q={term}&artist_uuid={artistUuid?}
```

`q` is trimmed server-side. Missing, blank, or shorter-than-3-character queries return all buckets as empty arrays.

### Breaking response shape

The source bucket is now plural:

```diff
- Source
+ Sources
```

Expected top-level shape:

```json
{
  "Artists": [],
  "Shows": [],
  "Songs": [],
  "Sources": [],
  "Tours": [],
  "Venues": []
}
```

Frontend migration:

1. Replace all reads of `result.Source` with `result.Sources`.
2. Keep existing bucket names for every other object type.
3. Treat every bucket as an array; disabled or empty buckets are returned as empty arrays, not omitted.

### Bucket toggles

All buckets default to `true`. Disable individual buckets with:

```text
artists=false
shows=false
songs=false
sources=false
tours=false
venues=false
```

Example, search only songs and shows:

```text
/api/v2/search?q=tweezer&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c&artists=false&sources=false&tours=false&venues=false
```

Example, tours only:

```text
/api/v2/search?q=summer&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c&artists=false&shows=false&songs=false&sources=false&venues=false
```

### Ordering

| Bucket | Ordering |
| --- | --- |
| `Artists` | show count descending, then name |
| `Shows` | source count descending, then display date descending |
| `Songs` | corrected play/show count descending, then name |
| `Sources` | weighted rating descending, duration descending, display date descending |
| `Tours` | show count descending, start date descending, then name |
| `Venues` | show count descending, then name |

### UUID fields

Search now populates UUID fields needed for navigation/cache keys:

| Bucket | UUID fields |
| --- | --- |
| `Artists` | `uuid` |
| `Shows` | `uuid`, `artist_uuid`, `venue_uuid`, `tour_uuid`, `year_uuid` |
| `Songs` | `uuid`, `artist_uuid` |
| `Sources` | `uuid`, `artist_uuid`, `show_uuid`, `venue_uuid` |
| `Tours` | `uuid`, `artist_uuid` |
| `Venues` | `uuid`, `artist_uuid` |

Some relationship UUIDs are legitimately nullable, such as `tour_uuid` for shows without tours and rare no-venue records.

### Count fix

`Songs[].shows_played_at` was previously inflated because search counted every Relisten show on the same calendar date across all artists. It now counts matching shows for the song's artist only.

## Validation

- `dotnet test RelistenApiTests/RelistenApiTests.csproj` -> 46 passed
- `git diff --check` -> clean
- Started local API and hit representative real endpoints:
  - `/api/v2/search?q=tweezer&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c`
  - `/api/v2/search?q=summer&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c&artists=false&shows=false&songs=false&sources=false&venues=false`
  - `/api/v2/search?q=garden&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c&artists=false&shows=false&songs=false&sources=false&tours=false`
  - `/api/v2/search?q=tw&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c`

### Artist filter change

The search endpoint now filters by `artist_uuid`, not numeric `artist_id`.

```diff
- /api/v2/search?q=tweezer&artist_id=4
+ /api/v2/search?q=tweezer&artist_uuid=ca53d281-0041-ae33-a050-c87702d93b0c
```

Frontend migration:

1. Pass the artist UUID from the selected artist model.
2. Stop sending `artist_id`; it is intentionally not part of the updated search contract.
3. No other search query parameters currently use numeric IDs.


### v3 route

This PR also exposes the same search endpoint at:

```text
GET /api/v3/search?q={term}&artist_uuid={artistUuid?}
```

Use v3 for new frontend work when possible. It uses the existing v3 serializer, so v2-only numeric fields such as `id`, `artist_id`, `show_id`, and `venue_id` are omitted from response objects while UUID fields remain present.
