### PR TITLE
Fix duplicate slug crash during Phish song import

### DIFF
--- a/RelistenApi/Services/Data/SetlistSongService.cs
+++ b/RelistenApi/Services/Data/SetlistSongService.cs
@@ -179,6 +179,10 @@ namespace Relisten.Data
                         @upstream_identifiers::text[],
                         @updated_ats::timestamp with time zone[]
                     ) AS t(artist_id, name, slug, upstream_identifier, updated_at)
+                    ON CONFLICT (artist_id, slug) DO UPDATE
+                        SET name = EXCLUDED.name,
+                            upstream_identifier = EXCLUDED.upstream_identifier,
+                            updated_at = EXCLUDED.updated_at
                     RETURNING *
                 ", new
                 {

--- a/RelistenApi/Services/Importers/PhishinImporter.cs
+++ b/RelistenApi/Services/Importers/PhishinImporter.cs
@@ -268,7 +268,12 @@ namespace Relisten.Import
                 }
             }
 
-            var newSongs = await _setlistSongService.InsertAll(artist, songsToSave);
+            var deduped = songsToSave
+                .GroupBy(s => s.slug)
+                .Select(g => g.First())
+                .ToList();
+
+            var newSongs = await _setlistSongService.InsertAll(artist, deduped);
 
             foreach (var s in newSongs)
             {

--- a/RelistenApi/Services/Importers/PhishinImporter.cs
+++ b/RelistenApi/Services/Importers/PhishinImporter.cs
@@ -268,16 +268,21 @@ namespace Relisten.Import
                 }
             }
 
-            var deduped = songsToSave
-                .GroupBy(s => s.slug)
-                .Select(g => g.First())
-                .ToList();
+            var groupedBySlug = songsToSave.GroupBy(s => s.slug).ToList();
+            var deduped = groupedBySlug.Select(g => g.First()).ToList();
 
             var newSongs = await _setlistSongService.InsertAll(artist, deduped);
 
-            foreach (var s in newSongs)
+            var newSongsBySlug = newSongs.ToDictionary(s => s.slug);
+            foreach (var group in groupedBySlug)
             {
-                existingSetlistSongs[s.upstream_identifier] = s;
+                if (newSongsBySlug.TryGetValue(group.Key, out var dbSong))
+                {
+                    foreach (var song in group)
+                    {
+                        existingSetlistSongs[song.upstream_identifier] = dbSong;
+                    }
+                }
             }
 
             stats.Created += newSongs.Count();


### PR DESCRIPTION
## Summary
- Phish.in can return multiple songs that map to the same slug (e.g. `further-on-up-the-road`), causing a `23505` unique constraint violation on `setlist_songs(artist_id, slug)` during import
- Deduplicate songs by slug within the batch before inserting
- Add `ON CONFLICT (artist_id, slug) DO UPDATE` to the insert so existing slugs are updated rather than rejected

## Test plan
- [ ] Run Phish import and confirm it completes without the `setlist_songs_artist_id_slug` constraint error
- [ ] Verify songs with duplicate slugs are present in the DB after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)