### PR TITLE
Add diagnostics and scrape-failure guard to PhishNet importer

### DIFF
--- a/RelistenApi/Services/Importers/PhishNet/PhishNetRatingsExtractor.cs
+++ b/RelistenApi/Services/Importers/PhishNet/PhishNetRatingsExtractor.cs
@@ -26,6 +26,7 @@ public class PhishNetRatingsScraper(HttpClient httpClient, string displayDate)
 
 public class PhishNetScrapeResults
 {
+    public bool RatingMatched { get; init; }
     public decimal RatingAverage { get; init; }
     public int RatingVotesCast { get; init; }
     public int NumberOfReviewsWritten { get; init; }
@@ -50,6 +51,7 @@ public partial class PhishNetRatingsExtractor(string pageContents)
 
         return new PhishNetScrapeResults
         {
+            RatingMatched = ratingMatches.Success,
             RatingAverage = ImporterUtils.TryParseDecimal(ratingMatches.Groups["AverageRating"].Value),
             RatingVotesCast = ImporterUtils.TryParseInt(ratingMatches.Groups["VotesCast"].Value),
             NumberOfReviewsWritten = PhishNetReviewCountScraper.Matches(PageContents).Count

--- a/RelistenApi/Services/Importers/PhishNetImporter.cs
+++ b/RelistenApi/Services/Importers/PhishNetImporter.cs
@@ -109,44 +109,54 @@ namespace Relisten.Import
             var ratings = await ScrapePhishNetForSource(dbSource, ctx);
             var dirty = false;
 
-            var newAvgRating = decimal.ToDouble(ratings.RatingAverage * 2.0m);
-
-            if (dbSource.num_ratings != ratings.RatingVotesCast
-                || Math.Abs(dbSource.avg_rating - newAvgRating) > 0.001)
+            if (!ratings.RatingMatched)
             {
-                dbSource.num_ratings = ratings.RatingVotesCast;
-                dbSource.avg_rating = newAvgRating;
+                ctx?.WriteLine($"{dbSource.display_date} skipping — failed to scrape ratings from phish.net");
+            }
+            else
+            {
+                var newAvgRating = decimal.ToDouble(ratings.RatingAverage * 2.0m);
 
-                dirty = true;
+                if (dbSource.num_ratings != ratings.RatingVotesCast
+                    || Math.Abs(dbSource.avg_rating - newAvgRating) > 0.001)
+                {
+                    ctx?.WriteLine($"{dbSource.display_date} ratings changed: num_ratings {dbSource.num_ratings} → {ratings.RatingVotesCast}, avg_rating {dbSource.avg_rating} → {newAvgRating}");
+                    dbSource.num_ratings = ratings.RatingVotesCast;
+                    dbSource.avg_rating = newAvgRating;
+
+                    dirty = true;
+                }
+
+                if (dbSource.num_reviews != ratings.NumberOfReviewsWritten)
+                {
+                    ctx?.WriteLine($"{dbSource.display_date} reviews changed: {dbSource.num_reviews} → {ratings.NumberOfReviewsWritten}");
+                    var reviews = await phishNetApiClient.Reviews(dbSource.display_date, ctx);
+
+                    var dbReviews = reviews.Select(rev => new SourceReview
+                    {
+                        rating = null,
+                        title = null,
+                        review = rev.review_text,
+                        author = rev.username,
+                        updated_at = rev.posted_at
+                    }).ToList();
+
+                    dbSource.num_reviews = dbReviews.Count;
+
+                    dirty = true;
+
+                    await ReplaceSourceReviews(stats, dbSource, dbReviews);
+                }
             }
 
             var phishNetApiShow = phishNetApiShows.FirstOrDefault(pnetShow => pnetShow.showdate == dbSource.display_date);
 
             if (!dbSource.description.Contains(phishNetApiShow!.setlist_notes))
             {
+                ctx?.WriteLine($"{dbSource.display_date} setlist_notes changed: [{dbSource.description.Length} chars] → [{phishNetApiShow.setlist_notes.Length} chars]");
                 dbSource.description = phishNetApiShow.setlist_notes;
 
                 dirty = true;
-            }
-
-            if (dbSource.num_reviews != ratings.NumberOfReviewsWritten)
-            {
-                var reviews = await phishNetApiClient.Reviews(dbSource.display_date, ctx);
-
-                var dbReviews = reviews.Select(rev => new SourceReview
-                {
-                    rating = null,
-                    title = null,
-                    review = rev.review_text,
-                    author = rev.username,
-                    updated_at = rev.posted_at
-                }).ToList();
-
-                dbSource.num_reviews = dbReviews.Count;
-
-                dirty = true;
-
-                await ReplaceSourceReviews(stats, dbSource, dbReviews);
             }
 
             if (dirty)

--- a/RelistenApiTests/Importers/PhishNet/TestPhishNetRatingsExtractor.cs
+++ b/RelistenApiTests/Importers/PhishNet/TestPhishNetRatingsExtractor.cs
@@ -24,7 +24,7 @@ public class TestPhishNetRatingsExtractor
 
         results.Should().BeEquivalentTo(new PhishNetScrapeResults
         {
-            RatingAverage = 4.636m, RatingVotesCast = 500, NumberOfReviewsWritten = 18
+            RatingMatched = true, RatingAverage = 4.636m, RatingVotesCast = 500, NumberOfReviewsWritten = 18
         });
     }
 
@@ -36,7 +36,7 @@ public class TestPhishNetRatingsExtractor
 
         results.Should().BeEquivalentTo(new PhishNetScrapeResults
         {
-            RatingAverage = 4.268m, RatingVotesCast = 50, NumberOfReviewsWritten = 4
+            RatingMatched = true, RatingAverage = 4.268m, RatingVotesCast = 50, NumberOfReviewsWritten = 4
         });
     }
 }


### PR DESCRIPTION
## Summary
- Log which field (ratings, reviews, or setlist_notes) triggered each "changed!" with old → new values, so we can identify why nearly every show is marked as changed
- Skip rating/review updates when the HTML scraper regex fails to match, preventing real data from being overwritten with zeros
- No behavioral change when scraping succeeds — just better visibility

## Test plan
- [ ] Deploy and run PhishNet importer, check logs to see which check is triggering the bulk "changed!" updates
- [ ] Verify shows with failed scrapes log the skip message instead of silently zeroing out ratings

🤖 Generated with [Claude Code](https://claude.com/claude-code)