### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -18,13 +18,13 @@ jobs:
     environment: relisten3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
           echo "package=${IMAGE_NAME#relistennet/}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -114,7 +114,7 @@ jobs:
           version: latest
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
         with:
           version: v1.36.2
 


### PR DESCRIPTION
## What changed

- Upgraded the workflow's JavaScript actions to their current Node.js 24-based major versions.
- Preserved all existing triggers, permissions, inputs, image tags, and deployment behavior.

## Why

GitHub now warns when Node.js 20-based actions are forced to run on Node.js 24. Updating the action majors removes that deprecation path before enforcement becomes stricter.

## Validation

- `actionlint` 1.7.12
- YAML parsing
- `git diff --check`
- Verified each selected action major declares `using: node24`

The deployment workflow was not dispatched because it publishes an image and restarts production.