### PR TITLE
fix(accounts): honor production database URL

### DIFF
--- a/RelistenUserService/Persistence/DatabaseConnectionString.cs
+++ b/RelistenUserService/Persistence/DatabaseConnectionString.cs
@@ -21,8 +21,11 @@ public static class DatabaseConnectionString
 
     public static string Resolve(IConfiguration configuration)
     {
-        var configured = configuration.GetConnectionString("Accounts")
-            ?? configuration["ACCOUNTS_DATABASE_URL"]
+        // Deployments provide ACCOUNTS_DATABASE_URL as a PostgreSQL URI. It must
+        // outrank file-based defaults so a local setting can never shadow the
+        // production Secret mounted by the deployment manifest.
+        var configured = configuration["ACCOUNTS_DATABASE_URL"]
+            ?? configuration.GetConnectionString("Accounts")
             ?? configuration["DATABASE_URL"];
 
         if (string.IsNullOrWhiteSpace(configured))

--- a/RelistenUserService/appsettings.Development.json
+++ b/RelistenUserService/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Accounts": "Host=localhost;Port=15432;Database=relisten_db;Username=relisten;Password=local_dev_password"
+  },
   "Accounts": {
     "Issuer": "http://localhost:5443",
     "EnableDevelopmentPersonas": true,

--- a/RelistenUserService/appsettings.json
+++ b/RelistenUserService/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "Accounts": "Host=localhost;Port=15432;Database=relisten_db;Username=relisten;Password=local_dev_password"
-  },
   "Accounts": {
     "Audience": "https://accounts.relisten.net",
     "AuthHost": "auth.relisten.net",

--- a/RelistenUserServiceTests/TestDatabaseConnectionString.cs
+++ b/RelistenUserServiceTests/TestDatabaseConnectionString.cs
@@ -49,6 +49,26 @@ public sealed class TestDatabaseConnectionString
         resolve.Should().Throw<InvalidOperationException>();
     }
 
+    [Test]
+    public void AccountsDatabaseUrlOverridesFileConnectionString()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Accounts"] =
+                    "Host=localhost;Database=local_accounts;Username=local;Password=local",
+                ["ACCOUNTS_DATABASE_URL"] =
+                    "postgresql://production:secret@accounts-db.internal/production_accounts"
+            })
+            .Build();
+
+        var resolved = DatabaseConnectionString.Resolve(configuration);
+        var builder = new NpgsqlConnectionStringBuilder(resolved);
+
+        builder.Host.Should().Be("accounts-db.internal");
+        builder.Database.Should().Be("production_accounts");
+    }
+
     private static IConfiguration BuildConfiguration(string connectionString) =>
         new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>


### PR DESCRIPTION
## Summary
- let `ACCOUNTS_DATABASE_URL` override file-based connection strings
- keep the localhost Postgres connection string in Development configuration only
- cover the production-over-local precedence invariant

## Verification
- `dotnet test RelistenUserServiceTests/RelistenUserServiceTests.csproj --no-restore` (45 passed)
- `dotnet build RelistenUserService/RelistenUserService.csproj --no-restore` (0 warnings, 0 errors)