### PR TITLE
fix(auth): coalesce duplicate OIDC claims

### DIFF
--- a/RelistenUserService/Authentication/ExternalIdentityProfileFactory.cs
+++ b/RelistenUserService/Authentication/ExternalIdentityProfileFactory.cs
@@ -11,8 +11,12 @@ internal static class ExternalIdentityProfileFactory
         string provider,
         ClaimsPrincipal principal)
     {
+        var registrationId = GetUnambiguousClaim(
+            principal,
+            Claims.Private.RegistrationId,
+            StringComparer.Ordinal);
         if (!string.Equals(
-                principal.GetClaim(Claims.Private.RegistrationId),
+                registrationId,
                 provider,
                 StringComparison.Ordinal))
         {
@@ -20,27 +24,37 @@ internal static class ExternalIdentityProfileFactory
                 "The external identity registration does not match its callback route.");
         }
 
-        var subject = principal.GetClaim(Claims.Subject);
+        var subject = GetUnambiguousClaim(
+            principal,
+            Claims.Subject,
+            StringComparer.Ordinal);
         if (string.IsNullOrWhiteSpace(subject))
         {
             throw new InvalidOperationException(
                 "The external provider returned no stable subject identifier.");
         }
 
-        var email = principal.GetClaim(Claims.Email);
+        var email = GetUnambiguousClaim(
+            principal,
+            Claims.Email,
+            StringComparer.OrdinalIgnoreCase);
+        var emailVerified = ParseBoolean(GetUnambiguousClaim(
+            principal,
+            Claims.EmailVerified,
+            StringComparer.OrdinalIgnoreCase));
         return provider switch
         {
             AuthenticationConstants.GoogleProvider => new(
                 AuthenticationConstants.GoogleIssuer,
                 subject,
                 email,
-                ParseBoolean(principal.GetClaim(Claims.EmailVerified)),
+                emailVerified,
                 false),
             AuthenticationConstants.AppleProvider => new(
                 AuthenticationConstants.AppleIssuer,
                 subject,
                 email,
-                ParseBoolean(principal.GetClaim(Claims.EmailVerified)),
+                emailVerified,
                 email is null
                     ? null
                     : email.EndsWith(
@@ -48,6 +62,28 @@ internal static class ExternalIdentityProfileFactory
                         StringComparison.OrdinalIgnoreCase)),
             _ => throw new InvalidOperationException(
                 $"External provider '{provider}' is not allowlisted.")
+        };
+    }
+
+    private static string? GetUnambiguousClaim(
+        ClaimsPrincipal principal,
+        string type,
+        StringComparer comparer)
+    {
+        // OIDC providers may emit the same claim in both the ID token and the
+        // user-info response. Equivalent duplicates are harmless; conflicting
+        // identity values must fail closed instead of depending on claim order.
+        var values = principal.FindAll(type)
+            .Select(claim => claim.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(comparer)
+            .ToArray();
+        return values.Length switch
+        {
+            0 => null,
+            1 => values[0],
+            _ => throw new InvalidOperationException(
+                $"The external provider returned conflicting '{type}' claims.")
         };
     }
 

--- a/RelistenUserServiceTests/TestExternalIdentityProfileFactory.cs
+++ b/RelistenUserServiceTests/TestExternalIdentityProfileFactory.cs
@@ -46,6 +46,45 @@ public sealed class TestExternalIdentityProfileFactory
     }
 
     [Test]
+    public void Google_coalesces_equivalent_claims_from_id_token_and_user_info()
+    {
+        var principal = Principal(
+            "google-subject",
+            "listener@example.com",
+            emailVerified: "true");
+        var identity = (ClaimsIdentity)principal.Identity!;
+        identity.AddClaim(new Claim(Claims.Subject, "google-subject"));
+        identity.AddClaim(new Claim(Claims.Email, "LISTENER@example.com"));
+        identity.AddClaim(new Claim(Claims.EmailVerified, "True"));
+
+        var profile = ExternalIdentityProfileFactory.Create(
+            AuthenticationConstants.GoogleProvider,
+            principal);
+
+        profile.Subject.Should().Be("google-subject");
+        profile.Email.Should().Be("listener@example.com");
+        profile.EmailVerified.Should().BeTrue();
+    }
+
+    [Test]
+    public void Conflicting_subject_claims_are_rejected()
+    {
+        var principal = Principal(
+            "google-subject",
+            "listener@example.com",
+            emailVerified: "true");
+        ((ClaimsIdentity)principal.Identity!).AddClaim(
+            new Claim(Claims.Subject, "different-google-subject"));
+
+        var action = () => ExternalIdentityProfileFactory.Create(
+            AuthenticationConstants.GoogleProvider,
+            principal);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*conflicting*'sub'*");
+    }
+
+    [Test]
     public void Missing_subject_is_rejected()
     {
         var action = () => ExternalIdentityProfileFactory.Create(


### PR DESCRIPTION
## Summary
- coalesce equivalent OIDC claims emitted by both the ID token and user-info response
- reject conflicting identity values instead of depending on claim order
- cover the production Google duplicate-claim shape

## Verification
- `dotnet test RelistenUserServiceTests/RelistenUserServiceTests.csproj --no-restore` (47 passed)
- `dotnet build RelistenUserService/RelistenUserService.csproj --no-restore` (0 warnings, 0 errors)