### PR TITLE
Fix Phish SourceSet UUID collisions

### DIFF
--- a/RelistenApi/Migrations/Manual/2026-08-23-phish-source-set-uuid-v2.sql
+++ b/RelistenApi/Migrations/Manual/2026-08-23-phish-source-set-uuid-v2.sql
@@ -1,0 +1,199 @@
+\set ON_ERROR_STOP on
+\pset pager off
+
+\echo 'Phish SourceSet UUID v2 migration'
+\echo 'Safe default: this file only runs read-only checks unless apply_phish_source_set_uuid_v2 is set to 1.'
+\echo 'Deploy the v2 SourceSet UUID code first, then run the apply phase through a direct connection to the PostgreSQL primary.'
+
+SELECT
+    current_database() AS database,
+    current_user AS database_user,
+    pg_is_in_recovery() AS is_replica,
+    current_setting('server_version') AS postgres_version;
+
+SELECT
+    artist.id,
+    artist.uuid,
+    artist.name,
+    artist.slug
+FROM artists artist
+WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid;
+
+WITH targets AS (
+    SELECT
+        source_set.id,
+        source_set.uuid AS current_uuid,
+        md5(source.uuid::text || '::source_set::' || source_set.index::text)::uuid AS legacy_uuid,
+        md5(source.uuid::text || '::source_set:v2::' || source_set.index::text)::uuid AS target_uuid
+    FROM source_sets source_set
+    JOIN sources source ON source.id = source_set.source_id
+    WHERE source.artist_id = (
+        SELECT artist.id
+        FROM artists artist
+        WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+    )
+)
+SELECT
+    count(*) AS source_sets,
+    count(*) FILTER (WHERE current_uuid = legacy_uuid) AS legacy_source_sets,
+    count(*) FILTER (WHERE current_uuid = target_uuid) AS v2_source_sets,
+    count(*) FILTER (WHERE current_uuid NOT IN (legacy_uuid, target_uuid)) AS unexpected_source_sets,
+    count(DISTINCT target_uuid) AS distinct_v2_uuids
+FROM targets;
+
+WITH targets AS (
+    SELECT
+        source_set.id,
+        md5(source.uuid::text || '::source_set:v2::' || source_set.index::text)::uuid AS target_uuid
+    FROM source_sets source_set
+    JOIN sources source ON source.id = source_set.source_id
+    WHERE source.artist_id = (
+        SELECT artist.id
+        FROM artists artist
+        WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+    )
+)
+SELECT count(*) AS v2_uuids_owned_by_other_rows
+FROM targets target
+JOIN source_sets existing
+  ON existing.uuid = target.target_uuid
+ AND existing.id <> target.id;
+
+\if :{?apply_phish_source_set_uuid_v2}
+  \if :apply_phish_source_set_uuid_v2
+    SELECT NOT pg_is_in_recovery() AS server_is_primary \gset
+    \if :server_is_primary
+      \echo 'Primary-server guard passed. Rotating Phish SourceSet UUIDs.'
+    \else
+      \echo 'ERROR: refusing to rotate SourceSet UUIDs on a replica.'
+      SELECT current_setting('relisten.source_set_uuid_v2_requires_primary');
+    \endif
+
+    BEGIN;
+    SET LOCAL lock_timeout = '10s';
+    SET LOCAL statement_timeout = '5min';
+
+    DO $verify_source_set_uuid_v2$
+    DECLARE
+        candidate_count bigint;
+        distinct_target_count bigint;
+    BEGIN
+        SELECT
+            count(*),
+            count(DISTINCT md5(source.uuid::text || '::source_set:v2::' || source_set.index::text)::uuid)
+        INTO candidate_count, distinct_target_count
+        FROM source_sets source_set
+        JOIN sources source ON source.id = source_set.source_id
+        WHERE source.artist_id = (
+            SELECT artist.id
+            FROM artists artist
+            WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+        );
+
+        IF candidate_count = 0 THEN
+            RAISE EXCEPTION 'No Phish SourceSets found; aborting';
+        END IF;
+
+        IF candidate_count <> distinct_target_count THEN
+            RAISE EXCEPTION
+                'v2 UUID collision within Phish SourceSets: % rows, % distinct targets',
+                candidate_count,
+                distinct_target_count;
+        END IF;
+
+        IF EXISTS (
+            SELECT 1
+            FROM source_sets source_set
+            JOIN sources source ON source.id = source_set.source_id
+            WHERE source.artist_id = (
+                SELECT artist.id
+                FROM artists artist
+                WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+            )
+              AND source_set.uuid NOT IN (
+                  md5(source.uuid::text || '::source_set::' || source_set.index::text)::uuid,
+                  md5(source.uuid::text || '::source_set:v2::' || source_set.index::text)::uuid
+              )
+        ) THEN
+            RAISE EXCEPTION 'A Phish SourceSet has an unexpected UUID; inspect before applying';
+        END IF;
+
+        IF EXISTS (
+            SELECT 1
+            FROM source_sets source_set
+            JOIN sources source ON source.id = source_set.source_id
+            JOIN source_sets existing
+              ON existing.uuid = md5(
+                  source.uuid::text || '::source_set:v2::' || source_set.index::text
+              )::uuid
+             AND existing.id <> source_set.id
+            WHERE source.artist_id = (
+                SELECT artist.id
+                FROM artists artist
+                WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+            )
+        ) THEN
+            RAISE EXCEPTION 'A v2 UUID is already owned by a different SourceSet row';
+        END IF;
+    END
+    $verify_source_set_uuid_v2$;
+
+    WITH candidates AS (
+        SELECT
+            source_set.id,
+            md5(source.uuid::text || '::source_set:v2::' || source_set.index::text)::uuid AS target_uuid
+        FROM source_sets source_set
+        JOIN sources source ON source.id = source_set.source_id
+        WHERE source.artist_id = (
+            SELECT artist.id
+            FROM artists artist
+            WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+        )
+    )
+    UPDATE source_sets source_set
+    SET uuid = candidate.target_uuid
+    FROM candidates candidate
+    WHERE source_set.id = candidate.id
+      AND source_set.uuid IS DISTINCT FROM candidate.target_uuid;
+
+    DO $verify_source_set_uuid_v2$
+    BEGIN
+        IF EXISTS (
+            SELECT 1
+            FROM source_sets source_set
+            JOIN sources source ON source.id = source_set.source_id
+            WHERE source.artist_id = (
+                SELECT artist.id
+                FROM artists artist
+                WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+            )
+              AND source_set.uuid IS DISTINCT FROM md5(
+                  source.uuid::text || '::source_set:v2::' || source_set.index::text
+              )::uuid
+        ) THEN
+            RAISE EXCEPTION 'Phish SourceSet UUID v2 verification failed';
+        END IF;
+    END
+    $verify_source_set_uuid_v2$;
+
+    COMMIT;
+  \endif
+\endif
+
+WITH targets AS (
+    SELECT
+        source_set.uuid AS current_uuid,
+        md5(source.uuid::text || '::source_set:v2::' || source_set.index::text)::uuid AS target_uuid
+    FROM source_sets source_set
+    JOIN sources source ON source.id = source_set.source_id
+    WHERE source.artist_id = (
+        SELECT artist.id
+        FROM artists artist
+        WHERE artist.uuid = 'ca53d281-0041-ae33-a050-c87702d93b0c'::uuid
+    )
+)
+SELECT
+    count(*) AS source_sets_after,
+    count(*) FILTER (WHERE current_uuid = target_uuid) AS v2_source_sets_after,
+    count(*) FILTER (WHERE current_uuid <> target_uuid) AS non_v2_source_sets_after
+FROM targets;

--- a/RelistenApi/Services/Data/SourceSetService.cs
+++ b/RelistenApi/Services/Data/SourceSetService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,6 +7,12 @@ using Relisten.Api.Models;
 
 namespace Relisten.Data
 {
+    public enum SourceSetUuidVersion
+    {
+        V1,
+        V2
+    }
+
     public class SourceSetService : RelistenDataServiceBase
     {
         public SourceSetService(DbService db) : base(db) { }
@@ -22,19 +29,21 @@ namespace Relisten.Data
             ", new {source_ids}));
         }
 
-        public async Task<SourceSet?> Update(Source source, SourceSet set)
+        public async Task<SourceSet?> Update(Source source, SourceSet set, SourceSetUuidVersion uuidVersion)
         {
             var l = new List<SourceSet>();
             l.Add(set);
 
-            return (await UpdateAll(source, l)).FirstOrDefault();
+            return (await UpdateAll(source, l, uuidVersion)).FirstOrDefault();
         }
 
-        public async Task<IEnumerable<SourceSet>> UpdateAll(Source source, IEnumerable<SourceSet> sets)
+        public async Task<IEnumerable<SourceSet>> UpdateAll(Source source, IEnumerable<SourceSet> sets,
+            SourceSetUuidVersion uuidVersion)
         {
             return await db.WithWriteConnection(async con =>
             {
                 var inserted = new List<SourceSet>();
+                var sourceSetUuidNamespace = UuidNamespaceFor(uuidVersion);
 
                 foreach (var set in sets)
                 {
@@ -46,7 +55,8 @@ namespace Relisten.Data
                         set.is_encore,
                         set.name,
                         set.updated_at,
-                        sourceUuid = source.uuid
+                        sourceUuid = source.uuid,
+                        sourceSetUuidNamespace
                     };
 
                     inserted.Add(await con.QuerySingleAsync<SourceSet>(@"
@@ -68,7 +78,7 @@ namespace Relisten.Data
                                 @is_encore,
                                 @name,
                                 @updated_at,
-                                md5(@sourceUuid || '::source_set::' || @index)::uuid
+                                md5(@sourceUuid || @sourceSetUuidNamespace || @index)::uuid
                             )
                         ON CONFLICT ON CONSTRAINT source_sets_source_id_index_key
                         DO
@@ -91,6 +101,16 @@ namespace Relisten.Data
 
                 return inserted;
             });
+        }
+
+        internal static string UuidNamespaceFor(SourceSetUuidVersion uuidVersion)
+        {
+            return uuidVersion switch
+            {
+                SourceSetUuidVersion.V1 => "::source_set::",
+                SourceSetUuidVersion.V2 => "::source_set:v2::",
+                _ => throw new ArgumentOutOfRangeException(nameof(uuidVersion), uuidVersion, null)
+            };
         }
     }
 }

--- a/RelistenApi/Services/Importers/ArchiveOrgImporter.cs
+++ b/RelistenApi/Services/Importers/ArchiveOrgImporter.cs
@@ -454,7 +454,10 @@ namespace Relisten.Import
                 (await linkService.AddLinksForSource(dbSource, LinksForSource(artist, dbSource, upstreamSrc)))
                 .Count();
 
-            var dbSet = (await _sourceSetService.UpdateAll(dbSource, new[] { CreateSetForSource(dbSource) }))
+            var dbSet = (await _sourceSetService.UpdateAll(
+                    dbSource,
+                    new[] { CreateSetForSource(dbSource) },
+                    SourceSetUuidVersion.V1))
                 .First();
             stats.Created++;
 

--- a/RelistenApi/Services/Importers/LocalImporter.cs
+++ b/RelistenApi/Services/Importers/LocalImporter.cs
@@ -307,7 +307,10 @@ namespace Relisten.Import
 
             var taperNotes = new List<string>();
 
-            var setMaps = (await _sourceSetService.UpdateAll(dbSource, sets.Values))
+            var setMaps = (await _sourceSetService.UpdateAll(
+                    dbSource,
+                    sets.Values,
+                    SourceSetUuidVersion.V1))
                 .GroupBy(s => s.index)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Single());
 

--- a/RelistenApi/Services/Importers/PanicStreamComImporter.cs
+++ b/RelistenApi/Services/Importers/PanicStreamComImporter.cs
@@ -283,7 +283,8 @@ namespace Relisten.Import
                     })).Count();
             }
 
-            var dbSet = await _sourceSetService.Update(dbSource,
+            var dbSet = await _sourceSetService.Update(
+                dbSource,
                 new SourceSet
                 {
                     source_id = dbSource.id,
@@ -291,7 +292,8 @@ namespace Relisten.Import
                     is_encore = false,
                     name = "Default Set",
                     updated_at = panicUpdatedAt
-                });
+                },
+                SourceSetUuidVersion.V1);
             stats.Created++;
 
             var trackIndex = 0;

--- a/RelistenApi/Services/Importers/PhishinImporter.cs
+++ b/RelistenApi/Services/Importers/PhishinImporter.cs
@@ -457,7 +457,10 @@ namespace Relisten.Import
                 }
             }
 
-            var setMaps = (await _sourceSetService.UpdateAll(dbSource, sets.Values.Where(s => s != null).Select(s => s!)))
+            var setMaps = (await _sourceSetService.UpdateAll(
+                    dbSource,
+                    sets.Values.Where(s => s != null).Select(s => s!),
+                    SourceSetUuidVersion.V2))
                 .GroupBy(s => s.index)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Single());
 

--- a/RelistenApiTests/Services/TestSourceSetService.cs
+++ b/RelistenApiTests/Services/TestSourceSetService.cs
@@ -1,0 +1,15 @@
+using FluentAssertions;
+using Relisten.Data;
+
+namespace RelistenApiTests.Services;
+
+[TestFixture]
+public class TestSourceSetService
+{
+    [TestCase(SourceSetUuidVersion.V1, "::source_set::")]
+    [TestCase(SourceSetUuidVersion.V2, "::source_set:v2::")]
+    public void UsesExpectedUuidNamespace(SourceSetUuidVersion version, string expectedNamespace)
+    {
+        SourceSetService.UuidNamespaceFor(version).Should().Be(expectedNamespace);
+    }
+}


### PR DESCRIPTION
## Summary

- make SourceSet UUID namespace selection explicit for every importer
- move only Phish SourceSets to `::source_set:v2::`; Archive.org, PanicStream, and local imports remain on v1
- add a guarded, idempotent SQL script to rotate all existing Phish SourceSet UUIDs
- leave SourceSet row IDs, SourceTrack foreign keys, and show/source timestamps unchanged

## Production scope

Read-only production checks currently find:

- 1,882 Phish sources/shows
- 5,555 Phish SourceSets, all using the legacy namespace
- 5,555 distinct v2 UUID targets
- zero target collisions

The other catalog SourceSets are not migrated.

## Rollout

1. Deploy this commit to all API and worker pods.
2. Run the migration through a direct connection to the PostgreSQL primary:

```sh
psql -X -v ON_ERROR_STOP=1 \
  -v apply_phish_source_set_uuid_v2=1 \
  -f RelistenApi/Migrations/Manual/2026-08-23-phish-source-set-uuid-v2.sql
```

Without the apply variable, the script performs read-only preflight and verification only. The apply path checks that it is on the primary, rejects unexpected UUIDs/collisions, updates in one transaction with timeouts, and verifies every Phish SourceSet is v2 before committing.

Because this deliberately does not advance the show-level timestamp, existing clients heal after their 24-hour ETag window expires and they revisit the show online.

## Testing

- `dotnet test RelistenApi.sln` — 78 API tests and 47 user-service tests passed
- production read-only rehearsal — 5,555 legacy targets and zero collisions
- disposable local apply rehearsal — first run updated all Phish fixtures, second run updated zero rows, and the non-Phish fixture remained v1
- `git diff --check`
- independent two-pass review — no findings
